### PR TITLE
Fixes #15 along with unit tests

### DIFF
--- a/src/parseEse.ts
+++ b/src/parseEse.ts
@@ -7,7 +7,7 @@ type CurrentSection = (typeof sections)[number] | null;
 
 const splitter = /:/g;
 function getParts(str: string): string[] {
-    return str.split(splitter).map((part) => part.trim());
+    return str.split(';')[0].trim().split(splitter).map((part) => part.trim());
 }
 
 export default function parseEse(input: string): ESE {
@@ -76,7 +76,7 @@ export default function parseEse(input: string): ESE {
                 startRange,
                 endRange,
                 ...visibilityCenterCoords
-            ] = line.split(':');
+            ] = line.split(';')[0].trim().split(':');
 
             const centers: Position[] = [];
             for (let i = 0; i + 1 < visibilityCenterCoords.length; i += 2) {

--- a/src/parseSct.ts
+++ b/src/parseSct.ts
@@ -43,7 +43,7 @@ type CurrentSection = (typeof sections)[number] | null;
 
 const splitter = /[\t ]+/g;
 function getParts(str: string): string[] {
-    return str.split(splitter).map((part) => part.trim());
+    return str.split(';')[0].trim().split(splitter).map((part) => part.trim());
 }
 
 export default function parseSct(input: string): SCT {

--- a/test/parseEse.test.ts
+++ b/test/parseEse.test.ts
@@ -23,7 +23,7 @@ describe('parse ESE', function () {
         expect(
             parseEse(`
 [FREETEXT]
-N062.33.29.800:E006.06.41.540:ENAL Parking:10
+N062.33.29.800:E006.06.41.540:ENAL Parking:10  ; test comment
 N062.33.30.490:E006.06.44.700:ENAL Parking:11
 N062.33.42.900:E006.07.13.408:ENAL Taxiways:A
         `)
@@ -57,7 +57,7 @@ N062.33.42.900:E006.07.13.408:ENAL Taxiways:A
         expect(
             parseEse(`
 [POSITIONS]
-ENZV_APP:Sola Approach:119.600:ZAR::ENZV:APP:::1001:7477:N058.52.36.000:E005.38.16.000
+ENZV_APP:Sola Approach:119.600:ZAR::ENZV:APP:::1001:7477:N058.52.36.000:E005.38.16.000  ; test comment
        `)
         ).to.eql({
             ...empty,

--- a/test/parseSct.test.ts
+++ b/test/parseSct.test.ts
@@ -71,7 +71,7 @@ E011.05.02.000
     });
 
     it('read defines (stored lowercase for case-insensitivity)', function () {
-        expect(parseSct('#define    COLOR_Building  3881787')).to.deep.equal({
+        expect(parseSct('#define    COLOR_Building  3881787 ; test comment')).to.deep.equal({
             ...empty,
             defines: {
                 color_building: Color.withNameAndValue('COLOR_Building', 3881787),
@@ -80,7 +80,7 @@ E011.05.02.000
     });
 
     it('read VOR', function () {
-        expect(parseSct('[VOR]\nAAL  116.700 N057.06.14.158 E009.59.34.108')).to.deep.equal({
+        expect(parseSct('[VOR]\nAAL  116.700 N057.06.14.158 E009.59.34.108 ; test comment')).to.deep.equal({
             ...empty,
             vor: [
                 {
@@ -93,7 +93,7 @@ E011.05.02.000
     });
 
     it('read NDB', function () {
-        expect(parseSct('[NDB]\nHEI  340.000 N065.19.32.008 E007.18.57.088')).to.deep.equal({
+        expect(parseSct('[NDB]\nHEI  340.000 N065.19.32.008 E007.18.57.088 ; test comment')).to.deep.equal({
             ...empty,
             ndb: [
                 {
@@ -106,7 +106,7 @@ E011.05.02.000
     });
 
     it('read FIXes', function () {
-        expect(parseSct('[FIXES]\n02RYG N059.21.23.579 E010.52.14.581')).to.deep.equal({
+        expect(parseSct('[FIXES]\n02RYG N059.21.23.579 E010.52.14.581 ; test comment')).to.deep.equal({
             ...empty,
             fixes: [
                 {
@@ -118,7 +118,7 @@ E011.05.02.000
     });
 
     it('read AIRPORTs', function () {
-        expect(parseSct('[AIRPORT]\nENGM 123.456 N060.12.10.000 E011.05.02.000 D')).to.deep.equal({
+        expect(parseSct('[AIRPORT]\nENGM 123.456 N060.12.10.000 E011.05.02.000 D ; test comment')).to.deep.equal({
             ...empty,
             airports: [
                 {
@@ -134,7 +134,7 @@ E011.05.02.000
     it('read RUNWAYs', function () {
         expect(
             parseSct(
-                '[RUNWAY]\n01L 19R 013 193 N060.11.06.000 E011.04.25.478 N060.12.57.841 E011.05.29.990 ENGM'
+                '[RUNWAY]\n01L 19R 013 193 N060.11.06.000 E011.04.25.478 N060.12.57.841 E011.05.29.990 ENGM ; test comment'
             )
         ).to.deep.equal({
             ...empty,
@@ -158,7 +158,7 @@ E011.05.02.000
             parseSct(`
 [ARTCC]
 TMA - Upper Limit - ENCN, Kjevik         N058.43.57.000 E008.34.38.000 N058.41.45.000 E008.38.44.000
-                                         N058.41.45.000 E008.38.44.000 N058.28.37.000 E009.02.52.000
+                                         N058.41.45.000 E008.38.44.000 N058.28.37.000 E009.02.52.000 ; test comment
                                          N058.28.37.000 E009.02.52.000 N058.24.22.000 E009.10.35.000
         `)
         ).to.eql({
@@ -192,7 +192,7 @@ TMA - Upper Limit - ENCN, Kjevik         N058.43.57.000 E008.34.38.000 N058.41.4
         expect(
             parseSct(`
 [ARTCC HIGH]
-Sector Border - BIRD | BIRD_N            N065.45.00.000 E000.00.00.000 N066.45.00.000 W010.00.00.000
+Sector Border - BIRD | BIRD_N            N065.45.00.000 E000.00.00.000 N066.45.00.000 W010.00.00.000 ; test comment
                                          N066.45.00.000 W010.00.00.000 N066.45.00.000 W011.00.00.000
                                          N066.45.00.000 W011.00.00.000 N066.45.00.000 W015.10.36.000
         `)
@@ -229,7 +229,7 @@ Sector Border - BIRD | BIRD_N            N065.45.00.000 E000.00.00.000 N066.45.0
             parseSct(`
 #define COLOR_TWR-CTR   13158600
 [ARTCC LOW]
-CTR - ENNA                               N070.20.00.000 E024.40.00.000 N070.20.00.000 E025.20.00.000 COLOR_TWR-CTR
+CTR - ENNA                               N070.20.00.000 E024.40.00.000 N070.20.00.000 E025.20.00.000 COLOR_TWR-CTR  ; test comment
                                          N070.20.00.000 E025.20.00.000 N069.45.00.000 E025.20.00.000 COLOR_TWR-CTR
                                          N069.45.00.000 E025.20.00.000 N069.45.00.000 E024.40.00.000 COLOR_TWR-CTR
                                          N069.45.00.000 E024.40.00.000 N070.20.00.000 E024.40.00.000 COLOR_TWR-CTR
@@ -273,8 +273,8 @@ CTR - ENNA                               N070.20.00.000 E024.40.00.000 N070.20.0
         expect(
             parseSct(`
 [HIGH AIRWAY]
-A494       N056.34.58.000 E030.40.27.001 N056.36.03.999 E030.24.50.000
-A494       N056.41.27.999 E029.00.56.998 N056.45.06.001 E027.54.06.001
+A494       N056.34.58.000 E030.40.27.001 N056.36.03.999 E030.24.50.000 ; test comment
+A494       N056.41.27.999 E029.00.56.998 N056.45.06.001 E027.54.06.001; test comment
 A494       N056.36.03.999 E030.24.50.000 N056.41.27.999 E029.00.56.998
 A494       N056.33.11.001 E031.04.33.999 N056.34.58.000 E030.40.27.001
         `)
@@ -314,7 +314,7 @@ A494       N056.33.11.001 E031.04.33.999 N056.34.58.000 E030.40.27.001
         expect(
             parseSct(`
 [LOW AIRWAY]
-A74        N069.08.30.001 E030.39.11.998 N068.37.00.001 E031.46.48.000
+A74        N069.08.30.001 E030.39.11.998 N068.37.00.001 E031.46.48.000 ; test comment
 A74        N069.25.18.998 E030.01.40.000 N069.08.30.001 E030.39.11.998
         `)
         ).to.eql({
@@ -345,8 +345,8 @@ A74        N069.25.18.998 E030.01.40.000 N069.08.30.001 E030.39.11.998
 [SID]
 ENGM SID VIPPA VEMIN5A                   N060.13.50.001 E010.47.04.999 N060.09.51.001 E010.35.54.999
                                          N060.09.51.001 E010.35.54.999 N059.35.19.111 E010.23.59.460
-                                         N059.35.19.111 E010.23.59.460 N059.10.08.799 E010.15.33.361
-                                         N059.10.08.799 E010.15.33.361 N058.56.33.000 E010.13.42.999
+                                         N059.35.19.111 E010.23.59.460 N059.10.08.799 E010.15.33.361 ; test comment
+                                         N059.10.08.799 E010.15.33.361 N058.56.33.000 E010.13.42.999; test comment
         `)
         ).to.eql({
             ...empty,
@@ -400,7 +400,7 @@ ENGM SID VIPPA VEMIN5A                   N060.13.50.001 E010.47.04.999 N060.09.5
             parseSct(`
 [VOR]
 SKG  112.800 N068.34.42.070 E015.02.05.729
-AND  112.200 N069.17.16.180 E016.08.28.971
+AND  112.200 N069.17.16.180 E016.08.28.971 ; A comment
 
 [FIXES]
 GILGU N069.29.38.630 E017.30.23.749
@@ -440,7 +440,7 @@ GILGU N069.29.38.630 E017.30.23.749
 #define COLOR_APP       13158600 
 
 [STAR]
-ENAL VORDME06                            N062.21.47.041 E005.47.59.690 N062.28.04.418 E005.41.28.359 COLOR_APP
+ENAL VORDME06                            N062.21.47.041 E005.47.59.690 N062.28.04.418 E005.41.28.359 COLOR_APP ; test comment
                                          N062.28.04.418 E005.41.28.359 N062.31.16.590 E005.40.11.240 COLOR_APP
         `)
         ).to.eql({
@@ -478,9 +478,9 @@ ENAL VORDME06                            N062.21.47.041 E005.47.59.690 N062.28.0
 #define COLOR_Taxiway      65280
 
 [GEO]
-ENCN Region                              N058.11.53.264 E008.04.26.812 N058.11.53.515 E008.04.28.153 COLOR_Stopbar
-                                         N058.12.15.241 E008.05.00.642 N058.12.15.883 E008.05.01.485 COLOR_Stopbar
-                                         N058.12.19.720 E008.05.06.676 N058.12.20.118 E008.05.06.563 COLOR_Stopbar
+ENCN Region                              N058.11.53.264 E008.04.26.812 N058.11.53.515 E008.04.28.153 COLOR_Stopbar  ; test comment
+                                         N058.12.15.241 E008.05.00.642 N058.12.15.883 E008.05.01.485 COLOR_Stopbar; test comment
+                                         N058.12.19.720 E008.05.06.676 N058.12.20.118 E008.05.06.563 COLOR_Stopbar   ; test comment
                                          N058.11.51.130 E008.04.35.435 N058.11.49.780 E008.04.33.652 COLOR_Taxiway
                                          N058.11.49.780 E008.04.33.652 N058.11.49.640 E008.04.33.396 COLOR_Taxiway
                                          N058.11.49.640 E008.04.33.396 N058.11.49.535 E008.04.33.143 COLOR_Taxiway
@@ -538,9 +538,9 @@ ENCN Region                              N058.11.53.264 E008.04.26.812 N058.11.5
 #define COLOR_Building   3881787
 [REGIONS]
 REGIONNAME ENAT
-COLOR_Building             N069.58.40.755 E023.21.13.825
-                           N069.58.40.262 E023.21.12.939
-                           N069.58.39.718 E023.21.15.557
+COLOR_Building             N069.58.40.755 E023.21.13.825 ; test comment
+                           N069.58.40.262 E023.21.12.939; another test comment
+                           N069.58.39.718 E023.21.15.557    ; third test comment
                            N069.58.40.215 E023.21.16.432
 REGIONNAME ENAT
 COLOR_Building             N069.58.40.092 E023.21.16.898


### PR DESCRIPTION
This PR fixes issues #15 and checks every possible sct items with a comment, including different comment separators (single space, double or tab).

Passes unit tests