### PR TITLE
Fix issue where comment is present in region name

### DIFF
--- a/src/parseSct.ts
+++ b/src/parseSct.ts
@@ -295,7 +295,7 @@ export default function parseSct(input: string): SCT {
             parseGeo(currentSection as GeoType);
         } else if (currentSection === 'REGIONS') {
             if (line.indexOf('REGIONNAME') === 0) {
-                currentRegion = line.substr(11);
+                currentRegion = line.slice(11).split(';')[0].trim();
                 regionsByName[currentRegion] = regionsByName[currentRegion] || [];
             } else {
                 const parts = getParts(line);

--- a/test/parseSct.test.ts
+++ b/test/parseSct.test.ts
@@ -545,7 +545,7 @@ ENCN Region                              N058.11.53.264 E008.04.26.812 N058.11.5
             parseSct(`
 #define COLOR_Building   3881787
 [REGIONS]
-REGIONNAME ENAT
+REGIONNAME ENAT ; test comment
 COLOR_Building             N069.58.40.755 E023.21.13.825 ; test comment
                            N069.58.40.262 E023.21.12.939; another test comment
                            N069.58.39.718 E023.21.15.557    ; third test comment


### PR DESCRIPTION
This fixes an issue where parsing would fail when a comment is placed next to a region name.

Also added test, all passing,