### PR TITLE
Add code for parsing ISEC.txt-files

### DIFF
--- a/src/parseIsec.ts
+++ b/src/parseIsec.ts
@@ -1,0 +1,23 @@
+import { Position } from './position.js';
+import { Navaid } from './sct.js';
+
+export default function parseIsec(input: string): Navaid[] {
+
+    const navaids: Navaid[] = [];
+
+    input
+        .split('\n')
+        .filter(line => line && !line.trim().startsWith(';'))
+        .map((str) => str.trim().split(/\s+/))
+        .filter((parts) => parts.length >= 3)
+        .forEach((parts) => {
+            console.log(parts);
+            const [fixname, lat, lon] = parts;
+            navaids.push({
+                id: fixname,
+                position: Position.latlonFloat(parseFloat(lat), parseFloat(lon)),
+            })
+        });
+
+    return navaids;
+}

--- a/src/parseSct.ts
+++ b/src/parseSct.ts
@@ -50,14 +50,14 @@ function getParts(str: string): string[] {
         .map((part) => part.trim());
 }
 
-export default function parseSct(input: string): SCT {
+export default function parseSct(input: string, isecNavaids?: Navaid[]): SCT {
     const lines = input.split('\n').map((line) => line.trim());
 
     const infoLines: string[] = [];
     const defines: { [key: string]: Color } = {};
     const vor: VOR[] = [];
     const ndb: NDB[] = [];
-    const navaids: { [name: string]: Navaid } = {};
+    const navaids: { [name: string]: Navaid } = isecNavaids ? Object.fromEntries(isecNavaids.map(navaid => [navaid.id, navaid])) : {};
     const fixes: FIX[] = [];
     const airports: Airport[] = [];
     const runways: Runway[] = [];

--- a/test/parseIsec.test.ts
+++ b/test/parseIsec.test.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { SCT, parseSct, Position, Color } from '../src';
+import parseIsec from '../src/parseIsec';
+
+describe('Parse ISEC-file', function () {
+    it('can parse empty string', function () {
+        expect(parseIsec('')).to.deep.equal([]);
+    });
+
+    it('skips empty lines', function () {
+        expect(parseIsec('\n\n\n')).to.deep.equal([]);
+    });
+
+    it('skips comments', function () {
+        expect(parseIsec(';comment\n\n\n')).to.deep.equal([]);
+    });
+
+    it('Read navaids', function () {
+        expect(
+            parseIsec(`
+                ;------------------------------------------------------
+                ; SOME  HEADER   TEXT !
+                ;------------------------------------------------------
+                ATLAP	 60.146094	   9.800694	15
+                GM402	 60.130306	  10.252833	15
+                OGRAS	 59.993703	  10.964169	15
+            `)
+        ).to.deep.equal([
+            { id: 'ATLAP', position: Position.latlonFloat(60.146094, 9.800694) },
+            { id: 'GM402', position: Position.latlonFloat(60.130306, 10.252833) },
+            { id: 'OGRAS', position: Position.latlonFloat(59.993703, 10.964169) },
+        ]);
+    });
+});

--- a/test/parseSct.test.ts
+++ b/test/parseSct.test.ts
@@ -21,6 +21,23 @@ const empty: SCT = {
     labels: [],
 };
 
+const SKG = {
+    id: 'SKG',
+    frequency: '112.800',
+    position: Position.latlon('N068.34.42.070', 'E015.02.05.729'),
+};
+
+const AND = {
+    id: 'AND',
+    frequency: '112.200',
+    position: Position.latlon('N069.17.16.180', 'E016.08.28.971'),
+};
+
+const GILGU = {
+    id: 'GILGU',
+    position: Position.latlon('N069.29.38.630', 'E017.30.23.749'),
+};
+
 describe('Parse SCT', function () {
     it('can parse empty string', function () {
         expect(parseSct('')).to.deep.equal(empty);
@@ -389,21 +406,6 @@ ENGM SID VIPPA VEMIN5A                   N060.13.50.001 E010.47.04.999 N060.09.5
     });
 
     it('read SID with navaids', function () {
-        const SKG = {
-            id: 'SKG',
-            frequency: '112.800',
-            position: Position.latlon('N068.34.42.070', 'E015.02.05.729'),
-        };
-        const AND = {
-            id: 'AND',
-            frequency: '112.200',
-            position: Position.latlon('N069.17.16.180', 'E016.08.28.971'),
-        };
-        const GILGU = {
-            id: 'GILGU',
-            position: Position.latlon('N069.29.38.630', 'E017.30.23.749'),
-        };
-
         expect(
             parseSct(`
 [VOR]
@@ -469,6 +471,41 @@ ENAL VORDME06                            N062.21.47.041 E005.47.59.690 N062.28.0
                             color,
                             start: Position.latlon('N062.28.04.418', 'E005.41.28.359'),
                             end: Position.latlon('N062.31.16.590', 'E005.40.11.240'),
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('use navaids from isec-file if not in sct-file', function () {
+        const isecData = [AND, SKG]
+
+        expect(
+            parseSct(`
+[FIXES]
+GILGU N069.29.38.630 E017.30.23.749
+
+[SID]
+0 FSS ENTC ALT Route                     SKG            SKG            AND            AND           
+                                         AND            AND            GILGU          GILGU
+        `, isecData)
+        ).to.eql({
+            ...empty,
+            fixes: [GILGU],
+            sid: [
+                {
+                    id: '0 FSS ENTC ALT Route',
+                    segments: [
+                        {
+                            color: null,
+                            start: SKG,
+                            end: AND,
+                        },
+                        {
+                            color: null,
+                            start: AND,
+                            end: GILGU,
                         },
                     ],
                 },


### PR DESCRIPTION
The sct-files may refer to navaids that are not  defined in the sct-file itself. These navaids are usually found in a separate
 isec.txt-file